### PR TITLE
always-pick-first-default-nic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## [0.1.1] 202-07-02
+
+## Changed
+- Pick primary default interface ip for the `DEFAULT_IPV4` value.
+
 ## [0.1.0] - 2020-06-30
 
 
@@ -17,6 +22,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Add base release.
 - Remove `dep` lefrovers
 
-[Unreleased]: https://github.com/giantswarm/k8s-setup-network-environment/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/giantswarm/k8s-setup-network-environment/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/giantswarm/k8s-setup-network-environment/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/giantswarm/k8s-setup-network-environment/compare/v0.0.0...v0.1.0
 [0.0.0]: https://github.com/giantswarm/k8s-setup-network-environment/releases/tag/v0.0.0

--- a/main.go
+++ b/main.go
@@ -132,11 +132,11 @@ func getDefaultGatewayIfaceName() (string, error) {
 
 	if len(defaultInterfaces) > 0 {
 		// sort interfaces  so we pick the first one properly
-
 		sort.Slice(defaultInterfaces, func(i, j int) bool {
 			return defaultInterfaces[i] < defaultInterfaces[j]
 		})
 
+		verboseLog(fmt.Sprintf("Using %s interface as first default.", defaultInterfaces[0]))
 		return defaultInterfaces[0], nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -130,11 +130,7 @@ func getDefaultGatewayIfaceName() (string, error) {
 	}
 
 	if len(defaultInterfaces) > 0 {
-		// sort interfaces  so we pick the first one properly
-		sort.Slice(defaultInterfaces, func(i, j int) bool {
-			return defaultInterfaces[i] < defaultInterfaces[j]
-		})
-
+		sortInterfaces(defaultInterfaces)
 		verboseLog(fmt.Sprintf("Found %s as primary default interface.", defaultInterfaces[0]))
 		return defaultInterfaces[0], nil
 	}
@@ -146,4 +142,12 @@ func verboseLog(msg string) {
 	if verboseOutput {
 		log.Println(msg)
 	}
+}
+
+func sortInterfaces(s []string) {
+	// sort interfaces  so we pick the first one properly
+	sort.Slice(s, func(i, j int) bool {
+		return s[i] < s[j]
+	})
+
 }

--- a/main.go
+++ b/main.go
@@ -73,7 +73,6 @@ func writeEnvironment(w io.Writer) error {
 			return err
 		}
 		for _, iface := range interfaces {
-
 			addrs, err := iface.Addrs()
 			if err != nil {
 				return err
@@ -136,7 +135,7 @@ func getDefaultGatewayIfaceName() (string, error) {
 			return defaultInterfaces[i] < defaultInterfaces[j]
 		})
 
-		verboseLog(fmt.Sprintf("Using %s interface as first default.", defaultInterfaces[0]))
+		verboseLog(fmt.Sprintf("Found %s as primary default interface.", defaultInterfaces[0]))
 		return defaultInterfaces[0], nil
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func Test_sortInterfaces(t *testing.T) {
+	testCases := []struct {
+		interfaces       []string
+		sortedInterfaces []string
+	}{
+		{
+			interfaces:       []string{"eth0"},
+			sortedInterfaces: []string{"eth0"},
+		},
+		{
+			interfaces:       []string{"eth1"},
+			sortedInterfaces: []string{"eth1"},
+		},
+		{
+			interfaces:       []string{"eth0", "eth1"},
+			sortedInterfaces: []string{"eth0", "eth1"},
+		},
+		{
+			interfaces:       []string{"eth1", "eth0"},
+			sortedInterfaces: []string{"eth0", "eth1"},
+		},
+		{
+			interfaces:       []string{"bond1", "bond0"},
+			sortedInterfaces: []string{"bond0", "bond1"},
+		},
+		{
+			interfaces:       []string{"eth1", "bond0"},
+			sortedInterfaces: []string{"bond0", "eth1"},
+		},
+		{
+			interfaces:       []string{"ens256", "ens224"},
+			sortedInterfaces: []string{"ens224", "ens256"},
+		},
+		{
+			interfaces:       []string{"eth4", "eth1", "eth0"},
+			sortedInterfaces: []string{"eth0", "eth1", "eth4"},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			sortInterfaces(tc.interfaces)
+
+			if !reflect.DeepEqual(tc.interfaces, tc.sortedInterfaces) {
+				t.Fatalf("%d: interfaces are not properly sorted expected %#v, got %#v\n", i, tc.sortedInterfaces, tc.interfaces)
+			}
+		})
+	}
+}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/11585

to sort cases where there are multiple NICs with default routes due to AWS networking and AWS CNI

this will check all routes and interfaces and it picks the primary one (with the smallest index)
before
```
compute.internal docker[4200]: netlink.NetworkGetRoutes() successful. Found 8 routes
compute.internal docker[4200]: Route 0: IFace = eth2, Default = true

 #: cat /etc/network-environment 
LO_IPV4=127.0.0.1
ETH0_IPV4=10.0.5.56
ETH1_IPV4=10.0.5.4
ETH2_IPV4=10.100.0.6
DEFAULT_IPV4=10.100.0.6  <----------------------
DOCKER0_IPV4=172.17.0.1
```

now:
```
compute.internal docker[7222]: netlink.NetworkGetRoutes() successful. Found 8 routes
compute.internal docker[7222]: Route 0: IFace = eth2, Default = true
compute.internal docker[7222]: Route 1: IFace = eth0, Default = true
compute.internal docker[7222]: Route 2: IFace = eth1, Default = false
compute.internal docker[7222]: Route 3: IFace = eth0, Default = false
compute.internal docker[7222]: Route 4: IFace = eth0, Default = false
compute.internal docker[7222]: Route 5: IFace = eth2, Default = false
compute.internal docker[7222]: Route 6: IFace = eth2, Default = false
compute.internal docker[7222]: Route 7: IFace = docker0, Default = false
compute.internal docker[7222]: Found eth0  as primary  default interface.

 #: cat /etc/network-environment 
LO_IPV4=127.0.0.1
ETH0_IPV4=10.0.5.56
DEFAULT_IPV4=10.0.5.56 <--------------------------
ETH1_IPV4=10.0.5.4
ETH2_IPV4=10.100.0.6
DOCKER0_IPV4=172.17.0.1
```